### PR TITLE
pin autoneg kube acc name to autoneg

### DIFF
--- a/terraform/gcp/main.tf
+++ b/terraform/gcp/main.tf
@@ -43,7 +43,7 @@ data "google_iam_policy" "autoneg_iam_policy" {
     role = "roles/iam.workloadIdentityUser"
 
     members = [
-      format("serviceAccount:%s.svc.id.goog[autoneg-system/default]", var.project_id)
+      format("serviceAccount:%s.svc.id.goog[autoneg-system/autoneg]", var.project_id)
     ]
   }
 }


### PR DESCRIPTION
should be tagged as 27.03.2023(for using with fresh autoneg chart)
and pinned at our terraform